### PR TITLE
Feature/colored coin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "tapyrus"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531da5de9edc4f127cde9058b234181a9f317acebe602a05f4e36e9e930c0556"
+checksum = "e1ab8cf59571e1fc3fecc61650a86869cf7bbfc1f4bf8305a6bd591d63d90e97"
 dependencies = [
  "bitcoin_hashes 0.8.0",
  "rug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ hyperlocal = "0.7"
 tokio = { version = "=0.2.6", features = ["sync", "macros"] }
 
 [dependencies.tapyrus]
-version = "^0.4.2"
+version = "^0.4.3"
 features = ["use-serde"]
 
 [dev-dependencies]

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,4 +1,4 @@
-pub use tapyrus::{util::address, Block, BlockHeader, OutPoint, Transaction, TxIn, TxOut};
+pub use tapyrus::{util::address, Block, BlockHeader, OutPoint, Script, Transaction, TxIn, TxOut};
 
 use tapyrus::network::constants::Network as BNetwork;
 use tapyrus::network::constants::NetworkId;

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -10,11 +10,11 @@ use crypto::sha2::Sha256;
 use error_chain::ChainedError;
 use hex;
 use serde_json::{from_str, Value};
-use tapyrus::blockdata::transaction::OutPoint;
 use tapyrus::blockdata::script::ColorIdentifier;
+use tapyrus::blockdata::transaction::OutPoint;
+use tapyrus::consensus::encode::{deserialize, serialize};
 use tapyrus::hashes::sha256d::Hash as Sha256dHash;
 use tapyrus::Txid;
-use tapyrus::consensus::encode::{deserialize, serialize};
 
 use crate::config::Config;
 use crate::electrum::{get_electrum_height, ProtocolVersion};
@@ -66,7 +66,6 @@ fn bool_from_value_or(val: Option<&Value>, name: &str, default: bool) -> Result<
     }
     bool_from_value(val, name)
 }
-
 
 fn color_id_from_value(val: Option<&Value>, name: &str) -> Result<Option<ColorIdentifier>> {
     if let Some(val) = val {
@@ -250,7 +249,7 @@ impl Connection {
                     "asset_quantity": asset.asset_quantity
                 }
             })
-        } else if let Some(color_id) = utxo.color_id.clone() {
+        } else if utxo.color_id.is_some() {
             json!({
                 "height": utxo.confirmed.clone().map_or(0, |b| b.height),
                 "tx_pos": utxo.vout,
@@ -504,6 +503,12 @@ impl Connection {
             "blockchain.scripthash.get_balance" => self.blockchain_scripthash_get_balance(&params),
             "blockchain.scripthash.get_history" => self.blockchain_scripthash_get_history(&params),
             "blockchain.scripthash.listunspent" => self.blockchain_scripthash_listunspent(&params),
+            "blockchain.scripthash.listcoloredunspent" => {
+                self.blockchain_scripthash_listcoloredunspent(&params)
+            }
+            "blockchain.scripthash.listuncoloredunspent" => {
+                self.blockchain_scripthash_listuncoloredunspent(&params)
+            }
             "blockchain.scripthash.subscribe" => self.blockchain_scripthash_subscribe(&params),
             "blockchain.transaction.broadcast" => self.blockchain_transaction_broadcast(&params),
             "blockchain.transaction.get" => self.blockchain_transaction_get(&params),

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -16,7 +16,7 @@ use crate::daemon::Daemon;
 use crate::errors::*;
 use crate::metrics::{GaugeVec, HistogramOpts, HistogramVec, MetricOpts, Metrics};
 use crate::new_index::{
-    compute_script_hash, schema::split_colored_script, schema::FullHash, ChainQuery, FundingInfo,
+    compute_script_hash, schema::FullHash, ChainQuery, FundingInfo,
     ScriptStats, SpendingInfo, SpendingInput, TxHistoryInfo, Utxo,
 };
 use crate::util::fees::{make_fee_histogram, TxFeeInfo};
@@ -334,7 +334,7 @@ impl Mempool {
                 .enumerate()
                 .filter(|(_, txo)| is_spendable(txo) || config.index_unspendables)
                 .map(|(index, txo)| {
-                    if let Some((color_id, script)) = split_colored_script(&txo.script_pubkey) {
+                    if let Some((color_id, script)) = txo.script_pubkey.split_color() {
                         vec![
                             (
                                 compute_script_hash(&txo.script_pubkey),

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1429,11 +1429,6 @@ impl TxHistoryRow {
     }
 }
 
-impl TxHistoryInfo {
-    // for funding rows, returns the funded output.
-    // for spending rows, returns the spent previous output.
-}
-
 #[derive(Serialize, Deserialize)]
 struct TxEdgeKey {
     code: u8,

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -999,15 +999,6 @@ fn index_blocks(
         .collect()
 }
 
-pub fn split_colored_script(script: &Script) -> Option<(ColorIdentifier, Script)> {
-    if script.is_colored() {
-        let color_id = deserialize(&script[1..34]).expect("unexpect color_id");
-        Some((color_id, Script::from(Vec::from(&script[35..]))))
-    } else {
-        None
-    }
-}
-
 // TODO: return an iterator?
 fn index_transaction(
     tx: &Transaction,
@@ -1024,7 +1015,7 @@ fn index_transaction(
     let txid = full_hash(&tx.malfix_txid()[..]);
     for (txo_index, txo) in tx.output.iter().enumerate() {
         if is_spendable(txo) || iconfig.index_unspendables {
-            if let Some((color_id, script)) = split_colored_script(&txo.script_pubkey) {
+            if let Some((color_id, script)) = txo.script_pubkey.split_color() {
                 let history = TxHistoryRow::new(
                     &txo.script_pubkey,
                     confirmed_height,


### PR DESCRIPTION
This PR add colored coin feature to esplora-tapyrus.

Update the following API to add color_id field to the response 
- blockchain.scripthash.listunspent

Add new API for colored coin
- blockchain.scripthash.listcoloredunspent
- blockchain.scripthash.listuncoloredunspent

this PR does not support blockchain.scripthash.get_balance API yet.
