### PR TITLE
Fix/script type for colored coin

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -4,8 +4,8 @@ use crate::errors;
 use crate::new_index::{compute_script_hash, Query, SpendingInput, Utxo};
 use crate::util::{
     create_socket, electrum_merkle, extract_tx_prevouts, full_hash, get_innerscripts,
-    get_script_asm, get_tx_fee, has_prevout, is_coinbase, script_to_address, BlockHeaderMeta,
-    BlockId, FullHash, TransactionStatus,
+    get_script_asm, get_script_type, get_tx_fee, has_prevout, is_coinbase, script_to_address,
+    BlockHeaderMeta, BlockId, FullHash, TransactionStatus,
 };
 
 use hex::{self, FromHexError};
@@ -202,34 +202,12 @@ impl TxOutValue {
     fn new(txout: &TxOut, config: &Config) -> Self {
         let value = txout.value;
 
-        let is_fee = false;
-
         let script = &txout.script_pubkey;
         let script_asm = get_script_asm(&script);
         let script_addr = script_to_address(&script, config.network);
 
         // TODO should the following something to put inside rust-elements lib?
-        let script_type = if is_fee {
-            "fee"
-        } else if script.is_empty() {
-            "empty"
-        } else if script.is_op_return() {
-            "op_return"
-        } else if script.is_p2pk() {
-            "p2pk"
-        } else if script.is_p2pkh() {
-            "p2pkh"
-        } else if script.is_p2sh() {
-            "p2sh"
-        } else if script.is_v0_p2wpkh() {
-            "v0_p2wpkh"
-        } else if script.is_v0_p2wsh() {
-            "v0_p2wsh"
-        } else if script.is_provably_unspendable() {
-            "provably_unspendable"
-        } else {
-            "unknown"
-        };
+        let script_type = get_script_type(&script);
 
         TxOutValue {
             scriptpubkey: script.clone(),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,7 +7,7 @@ pub mod fees;
 
 pub use self::block::{BlockHeaderMeta, BlockId, BlockMeta, BlockStatus, HeaderEntry, HeaderList};
 pub use self::fees::get_tx_fee;
-pub use self::script::{get_innerscripts, get_script_asm, script_to_address};
+pub use self::script::{get_innerscripts, get_script_asm, get_script_type, script_to_address};
 pub use self::transaction::{
     extract_tx_prevouts, has_prevout, is_coinbase, is_spendable, TransactionStatus, TxInput,
 };

--- a/src/util/script.rs
+++ b/src/util/script.rs
@@ -74,3 +74,46 @@ pub fn get_innerscripts(txin: &TxIn, prevout: &TxOut) -> InnerScripts {
         witness_script,
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::chain::Network;
+    use hex::FromHex;
+    use tapyrus::Script;
+
+    fn hex_script(hex: &str) -> Script {
+        return Script::from(Vec::from_hex(hex).unwrap());
+    }
+
+    #[test]
+    fn test_script_to_address() {
+        let script = hex_script("76a91437d8a6977e2b61459c594c8da713a2aeac7516b188ac");
+        let address = script_to_address(&script, Network::new("prod", 1)).unwrap();
+        assert_eq!(address, "166Hhi6oFtpMmugcLY2uyBFDC6caDFjT9s".to_string());
+
+        let script = hex_script("21c13c630f9d53c11847a662c963dfb1e05a8630dcb901262533cb2f590c480cc734bc76a91437d8a6977e2b61459c594c8da713a2aeac7516b188ac");
+        let address = script_to_address(&script, Network::new("prod", 1)).unwrap();
+        assert_eq!(
+            address,
+            "vhUcGQDo5abu4Ld1azfVWyzTDxFzYu9kk93VJ9ozv8zjq8vaGtGemPHKXfRnxPzbNXaxSk5sxd8Neh"
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_get_script_type() {
+        let p2pkh = hex_script("76a91437d8a6977e2b61459c594c8da713a2aeac7516b188ac");
+        assert_eq!(get_script_type(&p2pkh), "p2pkh".to_string());
+
+        let p2sh = hex_script("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787");
+        assert_eq!(get_script_type(&p2sh), "p2sh".to_string());
+
+        let cp2pkh = hex_script("21c13c630f9d53c11847a662c963dfb1e05a8630dcb901262533cb2f590c480cc734bc76a91437d8a6977e2b61459c594c8da713a2aeac7516b188ac");
+        assert_eq!(get_script_type(&cp2pkh), "cp2pkh".to_string());
+
+        let cp2sh = hex_script("21c13c630f9d53c11847a662c963dfb1e05a8630dcb901262533cb2f590c480cc734bca9143545e6e33b832c47050f24d3eeb93c9c03948bc787");
+        assert_eq!(get_script_type(&cp2sh), "cp2sh".to_string());
+    }
+}

--- a/src/util/script.rs
+++ b/src/util/script.rs
@@ -30,10 +30,6 @@ pub fn get_script_type(script: &Script) -> String {
         "p2pkh"
     } else if script.is_p2sh() {
         "p2sh"
-    } else if script.is_v0_p2wpkh() {
-        "v0_p2wpkh"
-    } else if script.is_v0_p2wsh() {
-        "v0_p2wsh"
     } else if script.is_provably_unspendable() {
         "provably_unspendable"
     } else if script.is_cp2pkh() {

--- a/src/util/script.rs
+++ b/src/util/script.rs
@@ -19,6 +19,33 @@ pub fn get_script_asm(script: &Script) -> String {
     (&asm[7..asm.len() - 1]).to_string()
 }
 
+pub fn get_script_type(script: &Script) -> String {
+    let script_type = if script.is_empty() {
+        "empty"
+    } else if script.is_op_return() {
+        "op_return"
+    } else if script.is_p2pk() {
+        "p2pk"
+    } else if script.is_p2pkh() {
+        "p2pkh"
+    } else if script.is_p2sh() {
+        "p2sh"
+    } else if script.is_v0_p2wpkh() {
+        "v0_p2wpkh"
+    } else if script.is_v0_p2wsh() {
+        "v0_p2wsh"
+    } else if script.is_provably_unspendable() {
+        "provably_unspendable"
+    } else if script.is_cp2pkh() {
+        "cp2pkh"
+    } else if script.is_cp2sh() {
+        "cp2sh"
+    } else {
+        "unknown"
+    };
+    return script_type.to_string();
+}
+
 // Returns the witnessScript in the case of p2wsh, or the redeemScript in the case of p2sh.
 pub fn get_innerscripts(txin: &TxIn, prevout: &TxOut) -> InnerScripts {
     // Wrapped redeemScript for P2SH spends


### PR DESCRIPTION
Now esplora REST API returns "unknown" type for colored output.
The following json is an example transaction data which includes colored output (vout = 0)

This PR fixes this problem and REST API will return "cp2pkh" or "cp2sh" as a scriptpubkey_type for colored outputs

```
{
    "txid": "2ca5f60e11f37d330c2494b8eed7062cde41b17b09f66a7d207a25921bf8e053",
    "version": 1,
    "locktime": 0,
    "vin": [
      {
        "txid": "bb32e22602ea8facebb5c5cbd43c40ac0ed4c1191cd07187d64043d93e815ad9",
        "vout": 0,
        "prevout": {
          "scriptpubkey": "76a91437d8a6977e2b61459c594c8da713a2aeac7516b188ac",
          "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 37d8a6977e2b61459c594c8da713a2aeac7516b1 OP_EQUALVERIFY OP_CHECKSIG",
          "scriptpubkey_type": "p2pkh",
          "scriptpubkey_address": "mkcEzmBn4vFcZ2AE471Ho6TY46DH9q8jgv",
          "value": 5000000000
        },
        "scriptsig": "47304402205354cc5a0ff5301d3bc444bb93360ebd5ee7e3bc9984cce7f3adda8a81903dc002205f126f4274a4d551ed5ee2a06397dc9a05a639355a5f241c94779a9faa40c1e50121033af76ee1584b8a7423baa6492b96fc5c0cb7c99749d40239044386c4e1fd65d0",
        "scriptsig_asm": "OP_PUSHBYTES_71 304402205354cc5a0ff5301d3bc444bb93360ebd5ee7e3bc9984cce7f3adda8a81903dc002205f126f4274a4d551ed5ee2a06397dc9a05a639355a5f241c94779a9faa40c1e501 OP_PUSHBYTES_33 033af76ee1584b8a7423baa6492b96fc5c0cb7c99749d40239044386c4e1fd65d0",
        "is_coinbase": false,
        "sequence": 4294967295
      }
    ],
    "vout": [
      {
        "scriptpubkey": "21c1ffe4c9ae514d2f4a3c07807616346acf2a709d306e547078acc95230f727d1f3bc76a91437d8a6977e2b61459c594c8da713a2aeac7516b188ac",
        "scriptpubkey_asm": "OP_PUSHBYTES_33 c1ffe4c9ae514d2f4a3c07807616346acf2a709d306e547078acc95230f727d1f3 OP_COLOR OP_DUP OP_HASH160 OP_PUSHBYTES_20 37d8a6977e2b61459c594c8da713a2aeac7516b1 OP_EQUALVERIFY OP_CHECKSIG",
        "scriptpubkey_type": "unknown",
        "scriptpubkey_address": "22VQ4pjvf5hGF8wx6MByBngFrHnz9CpveJdXDfezqKPW1pRdu7CYLGXh6cBsHDvyUnaufzaKr39w3ozq",
        "value": 10000
      },
      {
        "scriptpubkey": "76a914305e993346ffe2480c3e507bd73773eb932790db88ac",
        "scriptpubkey_asm": "OP_DUP OP_HASH160 OP_PUSHBYTES_20 305e993346ffe2480c3e507bd73773eb932790db OP_EQUALVERIFY OP_CHECKSIG",
        "scriptpubkey_type": "p2pkh",
        "scriptpubkey_address": "mjvi45Q34fiaVWLf9SE3fduWcvntaureBH",
        "value": 4999999700
      }
    ],
    "size": 260,
    "weight": 1040,
    "fee": 18446744073709541000,
    "status": {
      "confirmed": true,
      "block_height": 6,
      "block_hash": "479a7d9c3d7fb266312e4422d0bded6a6d1f0cab12a07a05a478cd901621319e",
      "block_time": 1616500376
    }
  }
``` 