### PR TITLE
Change the fields of REST API response using BlockValue

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -404,17 +404,11 @@ impl ChainQuery {
         Some(self.header_by_hash(hash)?.header().clone())
     }
 
-    pub fn get_mtp(&self, height: usize) -> u32 {
-        let _timer = self.start_timer("get_block_mtp");
-        self.store.indexed_headers.read().unwrap().get_mtp(height)
-    }
-
     pub fn get_block_with_meta(&self, hash: &BlockHash) -> Option<BlockHeaderMeta> {
         let _timer = self.start_timer("get_block_with_meta");
         let header_entry = self.header_by_hash(hash)?;
         Some(BlockHeaderMeta {
             meta: self.get_block_meta(hash)?,
-            mtp: self.get_mtp(header_entry.height()),
             header_entry,
         })
     }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -11,6 +11,7 @@ use crate::util::{
 use hex::{self, FromHexError};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Response, Server, StatusCode};
+use tapyrus::blockdata::block::XField;
 use tapyrus::consensus::encode;
 use tapyrus::hashes::hex::{FromHex, ToHex};
 use tapyrus::hashes::Error as HashError;
@@ -44,26 +45,31 @@ const CONF_FINAL: usize = 10; // reorgs deeper than this are considered unlikely
 struct BlockValue {
     id: String,
     height: u32,
-    version: i32,
-    timestamp: u32,
+    features: i32,
+    time: u32,
     tx_count: u32,
     size: u32,
     weight: u32,
     merkle_root: String,
     im_merkle_root: String,
     previousblockhash: Option<String>,
-    mediantime: u32,
     signature: Option<String>,
+    xfield_type: u8,
+    xfield: Option<String>,
 }
 
 impl BlockValue {
     fn new(blockhm: BlockHeaderMeta, _network: Network) -> Self {
         let header = blockhm.header_entry.header();
+        let xfield = match header.xfield {
+            XField::None => None,
+            _ => Some(header.xfield.to_string()),
+        };
         BlockValue {
             id: header.block_hash().to_hex(),
             height: blockhm.header_entry.height() as u32,
-            version: header.version,
-            timestamp: header.time,
+            features: header.version,
+            time: header.time,
             tx_count: blockhm.meta.tx_count,
             size: blockhm.meta.size,
             weight: blockhm.meta.weight,
@@ -74,8 +80,9 @@ impl BlockValue {
             } else {
                 None
             },
-            mediantime: blockhm.mtp,
             signature: header.proof.map(|p| encode::serialize_hex(&p)),
+            xfield_type: header.xfield.field_type(),
+            xfield: xfield,
         }
     }
 }

--- a/src/util/block.rs
+++ b/src/util/block.rs
@@ -10,8 +10,6 @@ use std::iter::FromIterator;
 use std::slice;
 use time::OffsetDateTime as DateTime;
 
-const MTP_SPAN: usize = 11;
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BlockId {
     pub height: usize,
@@ -233,23 +231,6 @@ impl HeaderList {
     pub fn iter(&self) -> slice::Iter<HeaderEntry> {
         self.headers.iter()
     }
-
-    /// Get the Median Time Past
-    pub fn get_mtp(&self, height: usize) -> u32 {
-        // Use the timestamp as the mtp of the genesis block.
-        // Matches tapyrusd's behaviour: tapyrus-cli getblock `tapyrus-cli getblockhash 0` | jq '.time == .mediantime'
-        if height == 0 {
-            self.headers.get(0).unwrap().header.time
-        } else if height > self.len() - 1 {
-            0
-        } else {
-            let mut timestamps = (height.saturating_sub(MTP_SPAN - 1)..=height)
-                .map(|p_height| self.headers.get(p_height).unwrap().header.time)
-                .collect::<Vec<_>>();
-            timestamps.sort_unstable();
-            timestamps[timestamps.len() / 2]
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -288,7 +269,6 @@ pub struct BlockMeta {
 pub struct BlockHeaderMeta {
     pub header_entry: HeaderEntry,
     pub meta: BlockMeta,
-    pub mtp: u32,
 }
 
 impl From<&BlockEntry> for BlockMeta {


### PR DESCRIPTION
This PR changes REST API response that uses BlockValue.

see #16

Removed fields: 

- version
- timestamp
- mediantime

New fields:
 
- features
- time
- xfield_type
- xfield
