### PR TITLE
Add time field to REST API /mempool/recent

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -208,6 +208,12 @@ Get a list of the last 10 transactions to enter the mempool.
 
 Each transaction object contains simplified overview data, with the following fields: `txid`, `fee`, `vsize`, `time` and `value`
 
+### `GET /mempool/txs[/:start_index]`
+
+Get a list of the transactions to enter the mempool (up to 25 transactions beginning at `start_index`).
+
+Each transaction object contains simplified overview data, with the following fields: `txid`, `fee`, `vsize`, `time` and `value`
+
 ## Fee estimates
 
 ### `GET /fee-estimates`

--- a/doc/API.md
+++ b/doc/API.md
@@ -206,7 +206,7 @@ The order of the txids is arbitrary and does not match tapyrusd's.
 
 Get a list of the last 10 transactions to enter the mempool.
 
-Each transaction object contains simplified overview data, with the following fields: `txid`, `fee`, `vsize` and `value`
+Each transaction object contains simplified overview data, with the following fields: `txid`, `fee`, `vsize`, `time` and `value`
 
 ## Fee estimates
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -15,8 +15,8 @@ use tapyrus::{BlockHash, Txid};
 use tapyrus::consensus::encode::{deserialize, serialize};
 
 use crate::chain::{Block, BlockHeader, Network, Transaction};
-use crate::new_index::mempool::MempoolTx;
 use crate::metrics::{HistogramOpts, HistogramVec, Metrics};
+use crate::new_index::mempool::MempoolTx;
 use crate::signal::Waiter;
 use crate::util::HeaderList;
 
@@ -501,10 +501,7 @@ impl Daemon {
     }
 
     pub fn getmempooltx(&self, txhash: &Txid) -> Result<MempoolTx> {
-        let res = self.request(
-            "getmempoolentry",
-            json!(txhash.to_hex()),
-        )?;
+        let res = self.request("getmempoolentry", json!(txhash.to_hex()))?;
         Ok(serde_json::from_value(res).chain_err(|| "invalid getmempoolentry reply")?)
     }
 

--- a/src/new_index/mod.rs
+++ b/src/new_index/mod.rs
@@ -1,7 +1,7 @@
 pub mod color;
 pub mod db;
 mod fetch;
-mod mempool;
+pub mod mempool;
 pub mod precache;
 mod query;
 pub mod schema;

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -286,9 +286,17 @@ impl Query {
         )
     }
 
-    pub fn get_colored_txs(&self, color_id: &ColorIdentifier, last_seen_txid: Option<&Txid>, limit: usize,) -> Vec<(Transaction, Option<BlockId>)> {
+    pub fn get_colored_txs(
+        &self,
+        color_id: &ColorIdentifier,
+        last_seen_txid: Option<&Txid>,
+        limit: usize,
+    ) -> Vec<(Transaction, Option<BlockId>)> {
         let mut txs = vec![];
-        txs.extend(self.chain().get_colored_txs(color_id, last_seen_txid, limit));
+        txs.extend(
+            self.chain()
+                .get_colored_txs(color_id, last_seen_txid, limit),
+        );
         txs.extend(self.mempool().get_colored_txs(color_id));
         txs
     }

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -444,7 +444,7 @@ impl ChainQuery {
 
     pub fn colored_history_iter_scan_reverse(
         &self,
-        color_id: &ColorIdentifier
+        color_id: &ColorIdentifier,
     ) -> ReverseScanIterator {
         self.store.history_db.iter_scan_reverse(
             &ColoredTxHistoryRow::filter(color_id),
@@ -718,7 +718,12 @@ impl ChainQuery {
         update_colored_stats(init_cache, &histories)
     }
 
-    pub fn get_colored_txs(&self, color_id: &ColorIdentifier, last_seen_txid: Option<&Txid>, limit: usize) -> Vec<(Transaction, Option<BlockId>)> {
+    pub fn get_colored_txs(
+        &self,
+        color_id: &ColorIdentifier,
+        last_seen_txid: Option<&Txid>,
+        limit: usize,
+    ) -> Vec<(Transaction, Option<BlockId>)> {
         let txids = self
             .colored_history_iter_scan_reverse(color_id)
             .map(|row| ColoredTxHistoryRow::from_row(row).get_txid())


### PR DESCRIPTION
This PR adds `time` field to REST API /mempool/recent needed for Tapyrus Explorer (https://github.com/chaintope/tapyrus-explorer/pull/69)

And add new REST API `GET /mempool/txs[:start_index]` to get the list of transactions in mempool with pagination feature.
