### PR TITLE
Update container

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,12 +6,25 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 1
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Install
-      run: cargo install --path .
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Install
+        run: cargo install --path .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,10 +20,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --release
       - name: Run tests
         run: cargo test --verbose
-      - name: Install
-        run: cargo install --path .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,23 @@
-FROM rust:1.44.1-slim-buster
+FROM rust:1.71.0-slim-buster
 
 RUN apt-get update
 RUN apt-get install -y clang cmake
 RUN apt-get install -y libsnappy-dev git protobuf-compiler
 RUN apt-get install -y m4
 
-RUN adduser --disabled-login --system --shell /bin/false --uid 1000 user
-
-WORKDIR /home/user
-COPY ./ /home/user
-RUN chown -R user .
-
-USER user
+WORKDIR /var/lib/electrs
+COPY ./ /var/lib/electrs
 
 RUN cargo build --release
 RUN cargo install --path .
 
 # Electrum RPC
-EXPOSE 50001
+EXPOSE 50001 60001
+
+# HTTP
+EXPOSE 3000 3001
 
 # Prometheus monitoring
-EXPOSE 4224
+EXPOSE 4224 14224
 
 STOPSIGNAL SIGINT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
-FROM rust:1.71.0-slim-buster
+FROM rust:1.71.0-slim-buster as builder
 
 RUN apt-get update
 RUN apt-get install -y clang cmake
 RUN apt-get install -y libsnappy-dev git protobuf-compiler
 RUN apt-get install -y m4
 
-WORKDIR /var/lib/electrs
-COPY ./ /var/lib/electrs
+WORKDIR /app
 
-RUN cargo build --release
-RUN cargo install --path .
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+RUN mkdir -p src && echo 'fn main() {}' > src/main.rs && cargo build --release
+
+COPY src src
+RUN CARGO_BUILD_INCREMENTAL=true cargo build --release
+
+FROM debian:buster-slim
+
+COPY --from=builder /app/target/release/electrs /bin/electrs
 
 # Electrum RPC
 EXPOSE 50001 60001


### PR DESCRIPTION
Currently, building the container fails to fetch dependent libraries with the following error:

```
5.777 Caused by:
5.777   failed to fetch `https://github.com/rust-lang/crates.io-index`
5.777 
5.777 Caused by:
5.777   error reading from the zlib stream; class=Zlib (5)
```

Upgrade the Rust container version so that the container builds normally. It also speeds up Docker builds.