### PR TITLE
Add musl target builds for glibc-independent binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - 'task-161-add-musl-static-build-for-release'
 
 env:
   CARGO_INCREMENTAL: 0
@@ -18,14 +20,27 @@ jobs:
             runner: ubuntu-latest
             artifact_name: electrs
             platform: x86_64-linux-gnu
+            use_cross: false
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             artifact_name: electrs
             platform: aarch64-linux-gnu
+            use_cross: false
           - target: aarch64-apple-darwin
             runner: macos-14
             artifact_name: electrs
             platform: aarch64-apple-darwin
+            use_cross: false
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            artifact_name: electrs
+            platform: x86_64-linux-musl
+            use_cross: true
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            artifact_name: electrs
+            platform: aarch64-linux-musl
+            use_cross: true
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -34,7 +49,12 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -50,17 +70,37 @@ jobs:
             target/
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --locked --target ${{ matrix.target }}
+
+      - name: Build (cargo)
+        if: ${{ !matrix.use_cross }}
         run: cargo build --release --locked
 
+      - name: Set binary path
+        id: binary
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            echo "path=target/${{ matrix.target }}/release/${{ matrix.artifact_name }}" >> $GITHUB_OUTPUT
+            echo "dir=target/${{ matrix.target }}/release" >> $GITHUB_OUTPUT
+          else
+            echo "path=target/release/${{ matrix.artifact_name }}" >> $GITHUB_OUTPUT
+            echo "dir=target/release" >> $GITHUB_OUTPUT
+          fi
+
       - name: Strip binary
-        run: strip target/release/${{ matrix.artifact_name }}
+        run: strip ${{ steps.binary.outputs.path }}
 
       - name: Create tarball
         env:
           ASSET_NAME: electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}
         run: |
-          cd target/release
+          cd ${{ steps.binary.outputs.dir }}
           tar czvf ${ASSET_NAME}.tar.gz ${{ matrix.artifact_name }}
 
       - name: Compute SHA256 (Linux)
@@ -68,7 +108,7 @@ jobs:
         env:
           ASSET_NAME: electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}
         run: |
-          cd target/release
+          cd ${{ steps.binary.outputs.dir }}
           sha256sum ${ASSET_NAME}.tar.gz > ${ASSET_NAME}.tar.gz.sha256
 
       - name: Compute SHA256 (macOS)
@@ -76,7 +116,7 @@ jobs:
         env:
           ASSET_NAME: electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}
         run: |
-          cd target/release
+          cd ${{ steps.binary.outputs.dir }}
           shasum -a 256 ${ASSET_NAME}.tar.gz > ${ASSET_NAME}.tar.gz.sha256
 
       - name: Upload artifact
@@ -84,10 +124,11 @@ jobs:
         with:
           name: electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}
           path: |
-            target/release/electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}.tar.gz
-            target/release/electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}.tar.gz.sha256
+            ${{ steps.binary.outputs.dir }}/electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}.tar.gz
+            ${{ steps.binary.outputs.dir }}/electrs-${{ steps.version.outputs.tag }}-${{ matrix.platform }}.tar.gz.sha256
 
   publish-crate:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -102,6 +143,7 @@ jobs:
         run: cargo publish
 
   release:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -21,26 +22,31 @@ jobs:
             artifact_name: electrs
             platform: x86_64-linux-gnu
             use_cross: false
+            strip: strip
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             artifact_name: electrs
             platform: aarch64-linux-gnu
             use_cross: false
+            strip: strip
           - target: aarch64-apple-darwin
             runner: macos-14
             artifact_name: electrs
             platform: aarch64-apple-darwin
             use_cross: false
+            strip: strip
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             artifact_name: electrs
             platform: x86_64-linux-musl
             use_cross: true
+            strip: strip
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-latest
             artifact_name: electrs
             platform: aarch64-linux-musl
             use_cross: true
+            strip: aarch64-linux-gnu-strip
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -93,8 +99,12 @@ jobs:
             echo "dir=target/release" >> $GITHUB_OUTPUT
           fi
 
+      - name: Install cross-arch strip tool
+        if: matrix.strip != 'strip' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
+
       - name: Strip binary
-        run: strip ${{ steps.binary.outputs.path }}
+        run: ${{ matrix.strip }} ${{ steps.binary.outputs.path }}
 
       - name: Create tarball
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             platform: x86_64-linux-musl
             use_cross: true
           - target: aarch64-unknown-linux-musl
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
             artifact_name: electrs
             platform: aarch64-linux-musl
             use_cross: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - 'task-161-add-musl-static-build-for-release'
 
 env:
   CARGO_INCREMENTAL: 0
@@ -22,31 +20,26 @@ jobs:
             artifact_name: electrs
             platform: x86_64-linux-gnu
             use_cross: false
-            strip: strip
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             artifact_name: electrs
             platform: aarch64-linux-gnu
             use_cross: false
-            strip: strip
           - target: aarch64-apple-darwin
             runner: macos-14
             artifact_name: electrs
             platform: aarch64-apple-darwin
             use_cross: false
-            strip: strip
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             artifact_name: electrs
             platform: x86_64-linux-musl
             use_cross: true
-            strip: strip
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-latest
             artifact_name: electrs
             platform: aarch64-linux-musl
             use_cross: true
-            strip: aarch64-linux-gnu-strip
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -55,12 +48,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -78,7 +66,7 @@ jobs:
 
       - name: Install cross
         if: matrix.use_cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build (cross)
         if: matrix.use_cross
@@ -98,13 +86,6 @@ jobs:
             echo "path=target/release/${{ matrix.artifact_name }}" >> $GITHUB_OUTPUT
             echo "dir=target/release" >> $GITHUB_OUTPUT
           fi
-
-      - name: Install cross-arch strip tool
-        if: matrix.strip != 'strip' && runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
-
-      - name: Strip binary
-        run: ${{ matrix.strip }} ${{ steps.binary.outputs.path }}
 
       - name: Create tarball
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 *.sublime*
 *~
 *.pyc
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "esplora-tapyrus"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arraydeque",
  "arrayref",
@@ -494,6 +494,7 @@ dependencies = [
  "dirs",
  "error-chain",
  "glob",
+ "gmp-mpfr-sys",
  "hex",
  "hyper",
  "hyperlocal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ features = ["force-cross"]
 lto = true
 panic = 'abort'
 codegen-units = 1
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esplora-tapyrus"
-version = "0.5.7"
+version = "0.5.8"
 authors = ["Chaintope Inc.", "Roman Zeyde (original author) <me@romanzey.de>"]
 description = "An efficient re-implementation of Electrum Server in Rust"
 license = "MIT"
@@ -51,6 +51,10 @@ tokio = { version = "1", features = ["sync", "macros"] }
 [dependencies.tapyrus]
 version = "^0.5.0"
 features = ["use-serde"]
+
+[dependencies.gmp-mpfr-sys]
+version = "~1.6"
+features = ["force-cross"]
 
 [profile.release]
 lto = true

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:main"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,8 @@
 [target.x86_64-unknown-linux-musl]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:main"
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5"
 
 [target.aarch64-unknown-linux-musl]
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5"
 pre-build = [
   # GMP's configure looks for tools named "aarch64-unknown-linux-musl-*"
   # but cross-rs provides them as "aarch64-linux-musl-*".

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,9 @@ image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:main"
 
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
+pre-build = [
+  # GMP's configure looks for tools named "aarch64-unknown-linux-musl-*"
+  # but cross-rs provides them as "aarch64-linux-musl-*".
+  # Create symlinks to bridge the naming mismatch.
+  "sh -c 'for tool in /usr/local/bin/aarch64-linux-musl-*; do ln -sf \"$tool\" \"/usr/local/bin/aarch64-unknown-linux-musl-$(basename $tool | sed s/aarch64-linux-musl-//)\"; done'",
+]


### PR DESCRIPTION
## Summary

- リリースCIに `x86_64-unknown-linux-musl` / `aarch64-unknown-linux-musl` ターゲットを追加し、glibc非依存の静的リンクバイナリを配布可能にした
- `cross` (cross-rs v0.2.5) によるDockerベースのmuslクロスコンパイル環境を構成
- `strip = true` を `[profile.release]` に統合し、全ターゲットで統一的にシンボル除去

## Background

GitHub Actions の `ubuntu-latest` が Ubuntu 24.04 (glibc 2.39) に切り替わり、リリースバイナリが glibc 2.38+ に依存するようになった。AL2023 (glibc 2.34) 等の環境で動作しないため、musl静的リンクバイナリの追加が必要。

## Changes

### `.github/workflows/release.yml`
- musl ターゲット2種をビルドマトリクスに追加（`use_cross` フラグで分岐）
- `cross` インストールステップ追加（musl ターゲットのみ）
- 成果物パスの条件分岐（`target/{target}/release/` vs `target/release/`）
- `fail-fast: false` 追加
- `publish-crate` / `release` に `if: startsWith(github.ref, 'refs/tags/')` ガード追加

### `Cross.toml`（新規）
- musl ターゲットの Docker イメージを v0.2.5 に固定
- aarch64 musl の GMP ツールチェイン名前解決用 symlink 設定

### `Cargo.toml`
- バージョン `0.5.7` → `0.5.8`
- `gmp-mpfr-sys` に `force-cross` フィーチャー追加（musl環境でのGMPビルド対応）
- `strip = true` を `[profile.release]` に追加

## New release assets
- `electrs-v0.5.8-{platform}.tar.gz` + `.sha256`
  - `aarch64-linux-musl` ← **NEW**
  - `x86_64-linux-musl` ← **NEW**
  - `aarch64-linux-gnu` (既存)
  - `x86_64-linux-gnu` (既存)
  - `aarch64-apple-darwin` (既存)

## Test plan

- [x] テスト用タグ `v0.5.8-rc1` で全5ターゲットのビルド成功を確認（[Run](https://github.com/chaintope/esplora-tapyrus/actions/runs/24334710257)）
- [x] musl バイナリがアーティファクトとして生成されることを確認
- [x] musl バイナリの `ldd` で `not a dynamic executable` を確認
- [x] AL2023 (glibc 2.34) 環境での起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)